### PR TITLE
複数取得時にカーソルの最後に到達した際の不具合を修正

### DIFF
--- a/backend/usecase/review.go
+++ b/backend/usecase/review.go
@@ -42,11 +42,11 @@ func (uc *ReviewUseCase) ListReviews(ctx context.Context, reviewId string, limit
 
 	nextCursor := ""
 	if len(rs) > limit {
-		// limit を超えた最初の要素を取得
+		// limit を超えた最初の要素の id を取得
 		nextCursor = rs[limit].ReviewId
+		// limit までの要素を取得
+		rs = rs[:limit]
 	}
-	// limit までの要素を取得
-	rs = rs[:limit]
 
 	// 取得するユーザーIdのスライスを作成する
 	uids := make([]entity.ImmutableId, len(rs))
@@ -90,11 +90,11 @@ func (uc *ReviewUseCase) ListMyReviews(ctx context.Context, authorId entity.Immu
 
 	nextCursor := ""
 	if len(rs) > limit {
-		// limit を超えた最初の要素を取得
+		// limit を超えた最初の要素の id を取得
 		nextCursor = rs[limit].ReviewId
+		// limit までの要素を取得
+		rs = rs[:limit]
 	}
-	// limit までの要素を取得
-	rs = rs[:limit]
 
 	user, err := uc.userRepo.GetUserByImmutableId(ctx, uc.DB, authorId)
 	if err != nil {

--- a/backend/usecase/user.go
+++ b/backend/usecase/user.go
@@ -39,11 +39,11 @@ func (uc *UserUseCase) ListUsers(ctx context.Context, immutableId entity.Immutab
 
 	nextCursor := ""
 	if len(users) > limit {
-		// limit を超えた最初の要素を取得
+		// limit を超えた最初の要素の id を取得
 		nextCursor = string(users[limit].ImmutableId)
+		// limit までの要素を取得
+		users = users[:limit]
 	}
-	// limit までの要素を取得
-	users = users[:limit]
 
 	resp := &UserListResponse{
 		Users:      users,


### PR DESCRIPTION
- limit を超えた場合の処理を後で関数化する